### PR TITLE
Cleanup skipping implemented on pytest level

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ To store fixtures to file run tests with `--store {file_path}`:
 To load fixtures from file run tests with `--load {file_path}`:
 
     python -m pytest --load {file_path}
+
+**BEWARE** When this plugin is in use cleanup of all the fixtures is **not**
+executed. This is necessary to successfully run tests with `--load`. However it
+is important to keep this fact in mind.


### PR DESCRIPTION
Generic cleanup skipping without a need to explicitly handle it in
fixtures. On the other hand uses private access == unstable interface
that can stop working one day.
